### PR TITLE
Allowing for inheritance from Devise::DeviseAuthyController

### DIFF
--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -27,7 +27,7 @@ module DeviseAuthy
 
       def is_signing_in?
         if devise_controller? && signed_in?(resource_name) &&
-           self.class == Devise::SessionsController or self.class.superclass == Devise::SessionsController && 
+           self.class == Devise::SessionsController || self.class.ancestors.include?(Devise::SessionsController) && 
            self.action_name == "create"
           return true
         end


### PR DESCRIPTION
`is_signing_in?` helper was failing to recognize a controller that was inherited from `Devise::DeviseAuthyController`.
