### PR TITLE
add expires to cookie remember_device

### DIFF
--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -11,7 +11,8 @@ module DeviseAuthy
       def remember_device
         cookies.signed[:remember_device] = {
           :value => Time.now.to_i,
-          :secure => !(Rails.env.test? || Rails.env.development?)
+          :secure => !(Rails.env.test? || Rails.env.development?),
+          :expires => resource_class.authy_remember_device.from_now
         }
       end
 


### PR DESCRIPTION
otherwise, cookie is expired when the browser session ends
