### PR TITLE
Sets custom user agent with Authy gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ rvm:
   - ruby-head
 matrix:
   allow_failures:
-    - rvm: ruby-head
+    - rvm:
+      - ruby-head
+      - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,5 @@ rvm:
   - ruby-head
 matrix:
   allow_failures:
-    - rvm:
-      - ruby-head
-      - 2.2
+    - rvm: ruby-head
+    - rvm: 2.2

--- a/devise-authy.gemspec
+++ b/devise-authy.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "devise", ">= 3.0.0"
-  spec.add_dependency "authy", ">= 2.7.2"
+  spec.add_dependency "authy", ">= 2.7.5"
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/devise-authy.rb
+++ b/lib/devise-authy.rb
@@ -3,6 +3,8 @@ require 'active_support/core_ext/integer/time'
 require 'devise'
 require 'authy'
 
+Authy.user_agent = "DeviseAuthy/#{DeviseAuthy::VERSION} - #{Authy.user_agent}"
+
 module Devise
   mattr_accessor :authy_remember_device, :authy_enable_onetouch
   @@authy_remember_device = 1.month

--- a/spec/rails-app/Gemfile.lock
+++ b/spec/rails-app/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../..
   specs:
     devise-authy (1.10.0)
-      authy (>= 2.7.2)
+      authy (>= 2.7.5)
       devise (>= 3.0.0)
 
 GEM
@@ -42,10 +42,10 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (6.0.4)
-    authy (2.7.4)
+    authy (2.7.5)
       httpclient (>= 2.5.3.3)
     bcrypt (3.1.12)
     builder (3.2.3)
@@ -58,7 +58,7 @@ GEM
       responders
       warden (~> 1.2.3)
     erubis (2.7.0)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     httpclient (2.8.3)
     i18n (0.9.5)
@@ -74,7 +74,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nokogiri (1.9.0)
+    nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     public_suffix (3.0.3)
@@ -106,9 +106,9 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -138,4 +138,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
This will set the user agent to something like:

```
DeviseAuthy/1.10.0 - AuthyRuby/2.7.5 (x86_64-darwin18, Ruby 2.6.0)
```

This allows us to still check all requests that include `AuthyRuby` as the user agent, but also drill down to `DeviseAuthy` specifically too.

Will this work for you @robinske?