### PR TITLE
Stops making API requests from tests.

### DIFF
--- a/devise-authy.gemspec
+++ b/devise-authy.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.9.11"
   spec.add_development_dependency "rdoc", "~> 4.3.0"
   spec.add_development_dependency "simplecov", "~> 0.16.1"
+  spec.add_development_dependency "webmock", "~> 3.7.6"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'orm/active_record'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'database_cleaner'
+require 'webmock/rspec'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.


### PR DESCRIPTION
It appears that this test suite was making requests to the sandbox API URL. This was recently causing time outs. This update adds webmock to block network requests from tests and uses rspec mocks to stub the response of the Authy library and test this implementation in a more robust and network independent manner.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
