### PR TITLE
Stop calling signed_in? before needed.

### DIFF
--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -40,7 +40,7 @@ module DeviseAuthy
       end
 
       def is_signing_in?
-        if devise_controller? && signed_in?(resource_name) &&
+        if devise_controller? &&
           is_devise_sessions_controller? &&
           self.action_name == "create"
           return true


### PR DESCRIPTION
`check_request_and_redirect_to_verify_token` is guarded by `is_signing_in?` but both of them make calls to `signed_in?` which in turn calls `warden.authenticate?` which actually signs a user in if the right details are in the request. `check_request_and_redirect_to_verify_token` actually calls `signed_in?` and means to, so it is not necessary to call `signed_in?1, particularly so early in the guard which is run on every controller action, in `is_signing_in?`.

Fixes #76.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
