### PR TITLE
Add remember_device for OneTouch Login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
-jobs:
   exclude:
     - rvm: 2.4
       gemfile: gemfiles/rails_6.gemfile

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -120,6 +120,7 @@ class Devise::DeviseAuthyController < DeviseController
     when 'pending'
       head 202
     when 'approved'
+      remember_device(@resource.id) if params[:remember_device].to_i == 1
       record_authy_authentication
       render json: { redirect: after_sign_in_path_for(@resource) }
     when 'denied'

--- a/app/views/devise/verify_authy.html.erb
+++ b/app/views/devise/verify_authy.html.erb
@@ -25,11 +25,12 @@
       (function(){
         var onetouchInterval = setInterval(function(){
           var onetouchRequest = new XMLHttpRequest();
+          var rememberDevice = document.getElementById("remember_device").checked ? '1' : '0';
           onetouchRequest.addEventListener("load", function(){
             if(this.status != 202) clearInterval(onetouchInterval);
             if(this.status == 200) window.location = JSON.parse(this.responseText).redirect;
           });
-          onetouchRequest.open("GET", "<%= polymorphic_path [resource_name, :authy_onetouch_status] %>?onetouch_uuid=<%= @onetouch_uuid %>");
+          onetouchRequest.open("GET", "<%= polymorphic_path [resource_name, :authy_onetouch_status] %>?remember_device="+rememberDevice+"&onetouch_uuid=<%= @onetouch_uuid %>");
           onetouchRequest.send();
         }, 3000);
       })();

--- a/app/views/devise/verify_authy.html.haml
+++ b/app/views/devise/verify_authy.html.haml
@@ -22,11 +22,12 @@
     (function(){
       var onetouchInterval = setInterval(function(){
         var onetouchRequest = new XMLHttpRequest();
+        var rememberDevice = document.getElementById("remember_device").checked ? '1' : '0';
         onetouchRequest.addEventListener("load", function(){
           if(this.status != 202) clearInterval(onetouchInterval);
           if(this.status == 200) window.location = JSON.parse(this.responseText).redirect;
         });
-        onetouchRequest.open("GET", "#{polymorphic_path [resource_name, :authy_onetouch_status]}?onetouch_uuid=#{@onetouch_uuid}");
+        onetouchRequest.open("GET", "#{polymorphic_path [resource_name, :authy_onetouch_status]}?remember_device="+rememberDevice+"onetouch_uuid=#{@onetouch_uuid}");
         onetouchRequest.send();
       }, 3000);
     })();

--- a/app/views/devise/verify_authy.html.haml
+++ b/app/views/devise/verify_authy.html.haml
@@ -27,7 +27,7 @@
           if(this.status != 202) clearInterval(onetouchInterval);
           if(this.status == 200) window.location = JSON.parse(this.responseText).redirect;
         });
-        onetouchRequest.open("GET", "#{polymorphic_path [resource_name, :authy_onetouch_status]}?remember_device="+rememberDevice+"onetouch_uuid=#{@onetouch_uuid}");
+        onetouchRequest.open("GET", "#{polymorphic_path [resource_name, :authy_onetouch_status]}?remember_device="+rememberDevice+"&onetouch_uuid=#{@onetouch_uuid}");
         onetouchRequest.send();
       }, 3000);
     })();

--- a/devise-authy.gemspec
+++ b/devise-authy.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "devise", ">= 3.0.0"
+  spec.add_dependency "devise", ">= 4.0.0"
   spec.add_dependency "authy", ">= 2.7.5"
 
   spec.add_development_dependency "appraisal", "~> 2.2"
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rdoc", "~> 4.3.0"
   spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "webmock", "~> 3.7.6"
-  spec.add_development_dependency "rails"
+  spec.add_development_dependency "rails", ">= 5"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "generator_spec"
   spec.add_development_dependency "database_cleaner", "~> 1.7"


### PR DESCRIPTION
Currently, there is no possibility of remember device when login process is through OneTouch. This fix takes the same checkbox used in `submit-token` form and retrieves `checked` state on every `onetouchInterval` execution, so every `onetouchRequest` sends the variable as a query string to the server (like `onetouch_uuid`). Then, `GET_authy_onetouch_status` method in `devise_authy_controller.rb` validates `remember_device` param and replicates `remember_device` helper in 'approved' case.

Fixes #127 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
