### PR TITLE
Update to use gem method Authy::OneTouch.approval_request_status

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -114,7 +114,7 @@ class Devise::DeviseAuthyController < DeviseController
   end
 
   def GET_authy_onetouch_status
-    response =  Authy::API.get_request("onetouch/json/approval_requests/#{params[:onetouch_uuid]}")
+    response = Authy::OneTouch.approval_request_status(:uuid => params[:onetouch_uuid])
     status = response.dig('approval_request', 'status')
     case status
     when 'pending'

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
         end
 
         it "should not request the one touch status" do
-          expect(Authy::API).not_to receive(:get_request)
+          expect(Authy::OneTouch).not_to receive(:approval_request_status)
           get :GET_authy_onetouch_status
         end
       end
@@ -77,7 +77,7 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
         end
 
         it "should not request the one touch status" do
-          expect(Authy::API).not_to receive(:get_request)
+          expect(Authy::OneTouch).not_to receive(:approval_request_status)
           get :GET_authy_onetouch_status
         end
       end
@@ -271,24 +271,24 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
       let(:uuid) { SecureRandom.uuid }
 
       it "should return a 202 status code when pending" do
-        allow(Authy::API).to receive(:get_request)
-          .with("onetouch/json/approval_requests/#{uuid}")
+        allow(Authy::OneTouch).to receive(:approval_request_status)
+          .with(:uuid => uuid)
           .and_return({ 'approval_request' => { 'status' => 'pending' }})
         get :GET_authy_onetouch_status, params: { onetouch_uuid: uuid }
         expect(response.code).to eq("202")
       end
 
       it "should return a 401 status code when denied" do
-        allow(Authy::API).to receive(:get_request)
-          .with("onetouch/json/approval_requests/#{uuid}")
+        allow(Authy::OneTouch).to receive(:approval_request_status)
+        .with(:uuid => uuid)
           .and_return({ 'approval_request' => { 'status' => 'denied' }})
         get :GET_authy_onetouch_status, params: { onetouch_uuid: uuid }
         expect(response.code).to eq("401")
       end
 
       it "should return a 500 status code when something else happens" do
-        allow(Authy::API).to receive(:get_request)
-          .with("onetouch/json/approval_requests/#{uuid}")
+        allow(Authy::OneTouch).to receive(:approval_request_status)
+        .with(:uuid => uuid)
           .and_return({})
         get :GET_authy_onetouch_status, params: { onetouch_uuid: uuid }
         expect(response.code).to eq("500")
@@ -296,8 +296,8 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
       describe "when approved" do
         before(:each) do
-          allow(Authy::API).to receive(:get_request)
-            .with("onetouch/json/approval_requests/#{uuid}")
+          allow(Authy::OneTouch).to receive(:approval_request_status)
+            .with(:uuid => uuid)
             .and_return({ 'approval_request' => { 'status' => 'approved' }})
           get :GET_authy_onetouch_status, params: { onetouch_uuid: uuid, remember_device: '0' }
         end
@@ -324,8 +324,8 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
       describe "when approved and remembered" do
         before(:each) do
-          allow(Authy::API).to receive(:get_request)
-            .with("onetouch/json/approval_requests/#{uuid}")
+          allow(Authy::OneTouch).to receive(:approval_request_status)
+            .with(:uuid => uuid)
             .and_return({ 'approval_request' => { 'status' => 'approved' }})
           get :GET_authy_onetouch_status, params: { onetouch_uuid: uuid, remember_device: '1' }
         end


### PR DESCRIPTION
Fixes #123

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
