### PR TITLE
Allows remember device when enabling 2FA for first time.

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -109,6 +109,7 @@ class Devise::DeviseAuthyController < DeviseController
     self.resource.authy_enabled = token.ok?
 
     if token.ok? && self.resource.save
+      remember_device(@resource.id) if params[:remember_device].to_i == 1
       record_authy_authentication
       set_flash_message(:notice, :enabled)
       redirect_to after_authy_verified_path_for(resource)

--- a/app/views/devise/verify_authy_installation.html.erb
+++ b/app/views/devise/verify_authy_installation.html.erb
@@ -4,6 +4,10 @@
   <legend><%= I18n.t('submit_token_title', {:scope => 'devise'}) %></legend>
   <%= label_tag :token %>
   <%= text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token' %>
+  <label>
+    <%= check_box_tag :remember_device %>
+    <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+  </label>
   <%= authy_request_sms_link %>
   <%= submit_tag I18n.t('enable_my_account', {:scope => 'devise'}), :class => 'btn' %>
 <% end %>

--- a/app/views/devise/verify_authy_installation.html.haml
+++ b/app/views/devise/verify_authy_installation.html.haml
@@ -3,6 +3,9 @@
   %legend= I18n.t('submit_token_title', {:scope => 'devise'})
   = label_tag :token
   = text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token'
+  %label
+    = check_box_tag :remember_device
+    %span= I18n.t('remember_device', {:scope => 'devise'})
   = authy_request_sms_link
   = submit_tag I18n.t('enable_my_account', {:scope => 'devise'}), :class => 'btn'
 


### PR DESCRIPTION
Fixes #90.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
