### PR TITLE
Display TOTP QR Code on installation failed

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -131,6 +131,10 @@ class Devise::DeviseAuthyController < DeviseController
       set_flash_message(:notice, :enabled)
       redirect_to after_authy_verified_path_for(resource)
     else
+      if resource_class.authy_enable_qr_code
+        response = Authy::API.request_qr_code(id: resource.authy_id)
+        @authy_qr_code = response.qr_code
+      end
       handle_invalid_token :verify_authy_installation, :not_enabled
     end
   end


### PR DESCRIPTION
When it fails installation, then it does not display TOTP QR code on its views.

This is a little inconvenience. So I've fixed it. Thanks.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
