### PR TITLE
Make I18n.t calls Ruby 3.0 compatible.

### DIFF
--- a/app/views/devise/enable_authy.html.erb
+++ b/app/views/devise/enable_authy.html.erb
@@ -1,7 +1,7 @@
-<h2><%= I18n.t('authy_register_title', {:scope => 'devise'}) %></h2>
+<h2><%= I18n.t('authy_register_title', scope: 'devise') %></h2>
 
 <%= enable_authy_form do %>
   <%= text_field_tag :country_code, '', :autocomplete => :off, :placeholder => I18n.t('devise.country'), :id => "authy-countries"%>
   <%= text_field_tag :cellphone, '', :autocomplete => :off, :placeholder => I18n.t('devise.cellphone'), :id => "authy-cellphone"%>
-  <p><%= submit_tag I18n.t('enable_authy', {:scope => 'devise'}) %></p>
+  <p><%= submit_tag I18n.t('enable_authy', scope: 'devise') %></p>
 <% end %>

--- a/app/views/devise/enable_authy.html.haml
+++ b/app/views/devise/enable_authy.html.haml
@@ -1,5 +1,5 @@
-%h2= I18n.t('authy_register_title', {:scope => 'devise'})
+%h2= I18n.t('authy_register_title', scope: 'devise')
 = enable_authy_form do
   = text_field_tag :country_code, '', :autocomplete => :off, :placeholder => I18n.t('devise.country'), :id => "authy-countries"
   = text_field_tag :cellphone, '', :autocomplete => :off, :placeholder => I18n.t('devise.cellphone'), :id => "authy-cellphone"
-  %p= submit_tag I18n.t('enable_authy', {:scope => 'devise'})
+  %p= submit_tag I18n.t('enable_authy', scope: 'devise')

--- a/app/views/devise/verify_authy.html.erb
+++ b/app/views/devise/verify_authy.html.erb
@@ -1,14 +1,14 @@
 <h2>
-  <%= I18n.t('submit_token_title', {:scope => 'devise'}) %>
+  <%= I18n.t('submit_token_title', scope: 'devise') %>
 </h2>
 
 <%= verify_authy_form do %>
-  <legend><%= I18n.t('submit_token_title', {:scope => 'devise'}) %></legend>
+  <legend><%= I18n.t('submit_token_title', scope: 'devise') %></legend>
   <%= label_tag 'authy-token' %>
   <%= text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token' %>
   <label>
     <%= check_box_tag :remember_device %>
-    <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+    <span><%= I18n.t('remember_device', scope: 'devise') %></span>
   </label>
 
   <!-- Help tooltip -->
@@ -17,7 +17,7 @@
   <!-- <%= link_to '?', '#', :id => 'authy-help' %> -->
 
   <%= authy_request_sms_link %>
-  <%= submit_tag I18n.t('submit_token', {:scope => 'devise'}), :class => 'btn' %>
+  <%= submit_tag I18n.t('submit_token', scope: 'devise'), :class => 'btn' %>
 <% end %>
 
 <% if @onetouch_uuid %>

--- a/app/views/devise/verify_authy.html.haml
+++ b/app/views/devise/verify_authy.html.haml
@@ -1,13 +1,13 @@
-%h2= I18n.t('authy_register_title', {:scope => 'devise'})
+%h2= I18n.t('authy_register_title', scope: 'devise')
 
 = verify_authy_form do
-  %legend= I18n.t('submit_token_title', {:scope => 'devise'})
+  %legend= I18n.t('submit_token_title', scope: 'devise')
   = hidden_field_tag :"#{resource_name}_id", @resource.id
   = label_tag 'authy-token'
   = text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token'
   %label
     = check_box_tag :remember_device
-    %span= I18n.t('remember_device', {:scope => 'devise'})
+    %span= I18n.t('remember_device', scope: 'devise')
 
   / Help Tooltip
   / You need to configure a help message.
@@ -15,7 +15,7 @@
   / = link_to '?', '#', :id => 'authy-help', :'data-message' => 'a message'
 
   = authy_request_sms_link
-  = submit_tag I18n.t('submit_token', {:scope => 'devise'}), :class => 'btn'
+  = submit_tag I18n.t('submit_token', scope: 'devise'), :class => 'btn'
 
 - if @onetouch_uuid
   :javascript

--- a/app/views/devise/verify_authy_installation.html.erb
+++ b/app/views/devise/verify_authy_installation.html.erb
@@ -1,18 +1,18 @@
-<h2><%= I18n.t('authy_verify_installation_title', {:scope => 'devise'}) %></h2>
+<h2><%= I18n.t('authy_verify_installation_title', scope: 'devise') %></h2>
 
 <% if @authy_qr_code %>
-  <%= image_tag @authy_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', {:scope => 'devise'}) %>
-  <p><%= I18n.t('authy_qr_code_instructions', {:scope => 'devise'}) %></p>
+  <%= image_tag @authy_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', scope: 'devise') %>
+  <p><%= I18n.t('authy_qr_code_instructions', scope: 'devise') %></p>
 <% end %>
 
 <%= verify_authy_installation_form do %>
-  <legend><%= I18n.t('submit_token_title', {:scope => 'devise'}) %></legend>
+  <legend><%= I18n.t('submit_token_title', scope: 'devise') %></legend>
   <%= label_tag :token %>
   <%= text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token' %>
   <label>
     <%= check_box_tag :remember_device %>
-    <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+    <span><%= I18n.t('remember_device', scope: 'devise') %></span>
   </label>
   <%= authy_request_sms_link %>
-  <%= submit_tag I18n.t('enable_my_account', {:scope => 'devise'}), :class => 'btn' %>
+  <%= submit_tag I18n.t('enable_my_account', scope: 'devise'), :class => 'btn' %>
 <% end %>

--- a/app/views/devise/verify_authy_installation.html.haml
+++ b/app/views/devise/verify_authy_installation.html.haml
@@ -1,16 +1,16 @@
-%h2= I18n.t('authy_verify_installation_title', {:scope => 'devise'})
+%h2= I18n.t('authy_verify_installation_title', scope: 'devise')
 
 - if @authy_qr_code
-  = image_tag @authy_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', {:scope => 'devise'})
-  %p= I18n.t('authy_qr_code_instructions', {:scope => 'devise'})
+  = image_tag @authy_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', scope: 'devise')
+  %p= I18n.t('authy_qr_code_instructions', scope: 'devise')
 
 = verify_authy_installation_form do
-  %legend= I18n.t('submit_token_title', {:scope => 'devise'})
+  %legend= I18n.t('submit_token_title', scope: 'devise')
   = label_tag :token
   = text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token'
   %label
     = check_box_tag :remember_device
-    %span= I18n.t('remember_device', {:scope => 'devise'})
+    %span= I18n.t('remember_device', scope: 'devise')
   = authy_request_sms_link
-  = submit_tag I18n.t('enable_my_account', {:scope => 'devise'}), :class => 'btn'
+  = submit_tag I18n.t('enable_my_account', scope: 'devise'), :class => 'btn'
 

--- a/lib/devise-authy/controllers/helpers.rb
+++ b/lib/devise-authy/controllers/helpers.rb
@@ -77,7 +77,7 @@ module DeviseAuthy
       end
 
       def send_one_touch_request(authy_id)
-        Authy::OneTouch.send_approval_request(id: authy_id, message: I18n.t('request_to_login', { :scope => 'devise' }))
+        Authy::OneTouch.send_approval_request(id: authy_id, message: I18n.t('request_to_login', scope: 'devise'))
       end
 
       def record_authy_authentication

--- a/lib/devise-authy/controllers/view_helpers.rb
+++ b/lib/devise-authy/controllers/view_helpers.rb
@@ -3,7 +3,7 @@ module DeviseAuthy
     module Helpers
       def authy_request_phone_call_link(opts = {})
         title = opts.delete(:title) do
-          I18n.t('request_phone_call', { :scope => 'devise' })
+          I18n.t('request_phone_call', scope: 'devise')
         end
         opts = {
           :id => "authy-request-phone-call-link",


### PR DESCRIPTION
Hi! It didn't work with Ruby 3.0 and the suggested changes gave deprecation warnings in 2.7.1. My changes should fix the issue.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
