### PR TITLE
Prevents to not break rails apps when Generic authenticator tokens are still not enabled at Authy Twilio 

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -111,7 +111,7 @@ class Devise::DeviseAuthyController < DeviseController
   def GET_verify_authy_installation
     if resource_class.authy_enable_qr_code
       response = Authy::API.request_qr_code(id: resource.authy_id)
-      @authy_qr_code = response.qr_code
+      @authy_qr_code = response.try(:qr_code)
     end
     render :verify_authy_installation
   end
@@ -133,7 +133,7 @@ class Devise::DeviseAuthyController < DeviseController
     else
       if resource_class.authy_enable_qr_code
         response = Authy::API.request_qr_code(id: resource.authy_id)
-        @authy_qr_code = response.qr_code
+        @authy_qr_code = response.try(:qr_code)
       end
       handle_invalid_token :verify_authy_installation, :not_enabled
     end

--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -111,7 +111,11 @@ class Devise::DeviseAuthyController < DeviseController
   def GET_verify_authy_installation
     if resource_class.authy_enable_qr_code
       response = Authy::API.request_qr_code(id: resource.authy_id)
-      @authy_qr_code = response.try(:qr_code)
+      begin
+        @authy_qr_code = response.qr_code
+      rescue
+        raise if resource_class.authy_raise_qr_code_errors
+      end
     end
     render :verify_authy_installation
   end
@@ -133,7 +137,11 @@ class Devise::DeviseAuthyController < DeviseController
     else
       if resource_class.authy_enable_qr_code
         response = Authy::API.request_qr_code(id: resource.authy_id)
-        @authy_qr_code = response.try(:qr_code)
+        begin
+          @authy_qr_code = response.qr_code
+        rescue
+          raise if resource_class.authy_raise_qr_code_errors
+        end
       end
       handle_invalid_token :verify_authy_installation, :not_enabled
     end

--- a/lib/devise-authy.rb
+++ b/lib/devise-authy.rb
@@ -4,10 +4,15 @@ require 'devise'
 require 'authy'
 
 module Devise
-  mattr_accessor :authy_remember_device, :authy_enable_onetouch, :authy_enable_qr_code
+  mattr_accessor  :authy_remember_device, 
+                  :authy_enable_onetouch, 
+                  :authy_enable_qr_code, 
+                  :authy_raise_qr_code_errors
+
   @@authy_remember_device = 1.month
   @@authy_enable_onetouch = false
   @@authy_enable_qr_code = false
+  @@authy_raise_qr_code_errors = true
 end
 
 module DeviseAuthy

--- a/lib/devise-authy/models/authy_authenticatable.rb
+++ b/lib/devise-authy/models/authy_authenticatable.rb
@@ -17,7 +17,7 @@ module Devise
           where(authy_id: authy_id).first
         end
 
-        Devise::Models.config(self, :authy_remember_device, :authy_enable_onetouch, :authy_enable_qr_code)
+        Devise::Models.config(self, :authy_remember_device, :authy_enable_onetouch, :authy_enable_qr_code, :authy_raise_qr_code_errors)
       end
     end
   end

--- a/lib/generators/devise_authy/install_generator.rb
+++ b/lib/generators/devise_authy/install_generator.rb
@@ -20,7 +20,9 @@ module DeviseAuthy
         "  # config.authy_enable_onetouch = false\n\n" +
         "  # Should generating QR codes for other authenticator apps be enabled?\n" +
         "  # Note: you need to enable this in your Twilio console.\n" +
-        "  # config.authy_enable_qr_code = false\n\n", :after => "Devise.setup do |config|\n"
+        "  # config.authy_enable_qr_code = false\n" +
+        "  # Should Authy raise errors when missing QR codes configurations?\n" +
+        "  # config.authy_raise_qr_code_errors = true\n", :after => "Devise.setup do |config|\n"
       end
 
       def add_initializer


### PR DESCRIPTION
While using the Authy Twilio integration with my rails application, I found when we enable `config.authy_enable_qr_code` at the `initializers/devise.rb` and still does not had enabled the `Generic authenticator tokens` at the Twilio Authy application it will break the rails application when trying to access the `response.qr_code` method:
<img width="913" alt="auth_manager_authy_error" src="https://user-images.githubusercontent.com/21313/126794788-45ab981a-f70d-46bd-b083-ca2a1fd09b47.png">

Since we have many environments, in order to protect our applications from a breakdown (in production for example) we decided to overwrite internally the `GET_verify_authy_installation` as this PR suggests to be considered by.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
