### PR TITLE
Converting resource name to symbol to use on polymorphic route arguments

### DIFF
--- a/lib/devise-authy/controllers/view_helpers.rb
+++ b/lib/devise-authy/controllers/view_helpers.rb
@@ -13,7 +13,7 @@ module DeviseAuthy
 
         link_to(
           title,
-          url_for([resource_name, :request_phone_call]),
+          url_for([resource_name.to_s.to_sym, :request_phone_call]),
           opts
         )
       end
@@ -30,14 +30,14 @@ module DeviseAuthy
 
         link_to(
           title,
-          url_for([resource_name, :request_sms]),
+          url_for([resource_name.to_s.to_sym, :request_sms]),
           opts
         )
       end
 
       def verify_authy_form(opts = {}, &block)
         opts = default_opts.merge(:id => 'devise_authy').merge(opts)
-        form_tag([resource_name, :verify_authy], opts) do
+        form_tag([resource_name.to_s.to_sym, :verify_authy], opts) do
           buffer = hidden_field_tag(:"#{resource_name}_id", @resource.id)
           buffer << capture(&block)
         end
@@ -45,14 +45,14 @@ module DeviseAuthy
 
       def enable_authy_form(opts = {}, &block)
         opts = default_opts.merge(opts)
-        form_tag([resource_name, :enable_authy], opts) do
+        form_tag([resource_name.to_s.to_sym, :enable_authy], opts) do
           capture(&block)
         end
       end
 
       def verify_authy_installation_form(opts = {}, &block)
         opts = default_opts.merge(opts)
-        form_tag([resource_name, :verify_authy_installation], opts) do
+        form_tag([resource_name.to_s.to_sym, :verify_authy_installation], opts) do
           capture(&block)
         end
       end

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -60,6 +60,41 @@ RSpec.describe DeviseAuthy::Views::Helpers, type: :helper do
         expect(form).to match(%r|action="/users/verify_authy_installation"|)
       end
     end
+  end
 
+  describe "request links when resource_name is empty" do
+    before do
+      allow_any_instance_of(ApplicationHelper).to receive(:resource_name).and_return(nil)
+    end
+
+    it 'requests phone call link' do
+      expect {
+        helper.authy_request_phone_call_link
+      }.to raise_error(NoMethodError, /undefined method `_request_phone_call_path/)
+    end
+
+    it 'requests sms link' do
+      expect {
+        helper.authy_request_sms_link
+      }.to raise_error(NoMethodError, /undefined method `_request_sms_path/)
+    end
+
+    it 'verify authy form' do
+      expect {
+        helper.verify_authy_form { "I'm in a verify authy form" }
+      }.to raise_error(NoMethodError, /undefined method `_verify_authy_path/)
+    end
+
+    it 'enable authy form' do
+      expect {
+        helper.enable_authy_form { "I'm in a enable authy form" }
+      }.to raise_error(NoMethodError, /undefined method `_enable_authy_path/)
+    end
+
+    it 'verify authy installation form' do
+      expect {
+        helper.verify_authy_installation_form { "I'm in a verify authy installation form" }
+      }.to raise_error(NoMethodError, /undefined method `_verify_authy_installation_path/)
+    end
   end
 end


### PR DESCRIPTION
- Fixes ArgumentError `Please use symbols for polymorphic route arguments ` at `DeviseAuthy::Views::Helpers ` specs to the current build;
- Test it when the given resource name is `nil` to raise a better error than `NoMethodError (undefined method 'to_sym' for nil:NilClass)` on polymorphic routes arguments access;

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
