### PR TITLE
when fetching resource, use the resource's primary key (don't assume it's id)

### DIFF
--- a/app/controllers/devise/devise_authy_controller.rb
+++ b/app/controllers/devise/devise_authy_controller.rb
@@ -189,7 +189,7 @@ class Devise::DeviseAuthyController < DeviseController
     @resource = send("current_#{resource_name}")
 
     if @resource.nil?
-      @resource = resource_class.find_by_id(session["#{resource_name}_id"])
+      @resource = resource_class.send("find_by_#{resource_class.primary_key}", [session["#{resource_name}_id"]])
     end
   end
 


### PR DESCRIPTION
Rails allows you to set the primary key on an ActiveRecord model to a column other than id (https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/PrimaryKey/ClassMethods.html#method-i-primary_key)

When fetching resources authy-devise currently assumes that the primary key is the id column which will not work for any model using another key.

This change looks up the resource's primary key and then performs a find_by_ query with that key.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
