### PR TITLE
Fixes tests with url helpers and form_tag.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, head]
+        ruby: [2.5, 2.6, 2.7, "3.0", 3.1, head]
         gemfile: [rails_5_2, rails_6]
         exclude:
           - ruby: 3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ jobs:
         ruby: [2.5, 2.6, 2.7, "3.0", 3.1, head]
         gemfile: [rails_5_2, rails_6]
         exclude:
-          - ruby: 3.0
+          - ruby: "3.0"
+            gemfile: rails_5_2
+          - ruby: 3.1
             gemfile: rails_5_2
           - ruby: head
             gemfile: rails_5_2

--- a/Appraisals
+++ b/Appraisals
@@ -12,8 +12,7 @@ end if RUBY_VERSION.to_f < 3.0
 appraise "rails-6" do
   gem "rails", "~> 6.0.0"
   gem "sqlite3", "~> 1.4"
-
-  gem "net-smtp" if RUBY_VERSION.to_f > 3.0
+  gem "net-smtp"
 
   group :development, :test do
     gem 'factory_girl_rails', :require => false

--- a/Appraisals
+++ b/Appraisals
@@ -13,6 +13,8 @@ appraise "rails-6" do
   gem "rails", "~> 6.0.0"
   gem "sqlite3", "~> 1.4"
 
+  gem "net-smtp" if RUBY_VERSION.to_f > 3.0
+
   group :development, :test do
     gem 'factory_girl_rails', :require => false
     gem 'rspec-rails', "~>4.0.0.beta3", :require => false

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
 gem "sqlite3", "~> 1.4"
+gem "net-smtp"
 
 group :development, :test do
   gem "factory_girl_rails", require: false

--- a/lib/devise-authy/controllers/view_helpers.rb
+++ b/lib/devise-authy/controllers/view_helpers.rb
@@ -13,7 +13,7 @@ module DeviseAuthy
 
         link_to(
           title,
-          url_for([resource_name, :request_phone_call]),
+          url_for([resource_name.to_sym, :request_phone_call]),
           opts
         )
       end
@@ -30,14 +30,14 @@ module DeviseAuthy
 
         link_to(
           title,
-          url_for([resource_name, :request_sms]),
+          url_for([resource_name.to_sym, :request_sms]),
           opts
         )
       end
 
       def verify_authy_form(opts = {}, &block)
         opts = default_opts.merge(:id => 'devise_authy').merge(opts)
-        form_tag([resource_name, :verify_authy], opts) do
+        form_tag([resource_name.to_sym, :verify_authy], opts) do
           buffer = hidden_field_tag(:"#{resource_name}_id", @resource.id)
           buffer << capture(&block)
         end
@@ -45,14 +45,14 @@ module DeviseAuthy
 
       def enable_authy_form(opts = {}, &block)
         opts = default_opts.merge(opts)
-        form_tag([resource_name, :enable_authy], opts) do
+        form_tag([resource_name.to_sym, :enable_authy], opts) do
           capture(&block)
         end
       end
 
       def verify_authy_installation_form(opts = {}, &block)
         opts = default_opts.merge(opts)
-        form_tag([resource_name, :verify_authy_installation], opts) do
+        form_tag([resource_name.to_sym, :verify_authy_installation], opts) do
           capture(&block)
         end
       end

--- a/lib/generators/devise_authy/devise_authy_generator.rb
+++ b/lib/generators/devise_authy/devise_authy_generator.rb
@@ -3,22 +3,21 @@
 module DeviseAuthy
   module Generators
     class DeviseAuthyGenerator < Rails::Generators::NamedBase
-
       namespace "devise_authy"
 
       desc "Add :authy_authenticatable directive in the given model, plus accessors. Also generate migration for ActiveRecord"
 
       def inject_devise_authy_content
-        path = File.join(destination_root, "app","models","#{file_path}.rb")
+        path = File.join(destination_root, "app", "models", "#{file_path}.rb")
         if File.exists?(path) &&
-          !File.read(path).include?("authy_authenticatable")
+           !File.read(path).include?("authy_authenticatable")
           inject_into_file(path,
                            "authy_authenticatable, :",
                            :after => "devise :")
         end
 
         if File.exists?(path) &&
-          !File.read(path).include?(":authy_id")
+           !File.read(path).include?(":authy_id")
           inject_into_file(path,
                            ":authy_id, :last_sign_in_with_authy, ",
                            :after => "attr_accessible ")
@@ -26,7 +25,6 @@ module DeviseAuthy
       end
 
       hook_for :orm
-
     end
   end
 end

--- a/lib/generators/devise_authy/devise_authy_generator.rb
+++ b/lib/generators/devise_authy/devise_authy_generator.rb
@@ -9,14 +9,14 @@ module DeviseAuthy
 
       def inject_devise_authy_content
         path = File.join(destination_root, "app", "models", "#{file_path}.rb")
-        if File.exists?(path) &&
+        if File.exist?(path) &&
            !File.read(path).include?("authy_authenticatable")
           inject_into_file(path,
                            "authy_authenticatable, :",
                            :after => "devise :")
         end
 
-        if File.exists?(path) &&
+        if File.exist?(path) &&
            !File.read(path).include?(":authy_id")
           inject_into_file(path,
                            ":authy_id, :last_sign_in_with_authy, ",

--- a/lib/generators/devise_authy/install_generator.rb
+++ b/lib/generators/devise_authy/install_generator.rb
@@ -73,7 +73,7 @@ module DeviseAuthy
           }
         }.each do |extension, opts|
           file_path = File.join(destination_root, "app", "views", "layouts", "application.html.#{extension}")
-          if File.exists?(file_path) && !File.read(file_path).include?("form.authy.min.js")
+          if File.exist?(file_path) && !File.read(file_path).include?("form.authy.min.js")
             inject_into_file(file_path, opts.delete(:content), opts)
           end
         end

--- a/spec/controllers/devise_authy_controller_spec.rb
+++ b/spec/controllers/devise_authy_controller_spec.rb
@@ -128,11 +128,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
       describe "with a valid token" do
         before(:each) {
-          expect(Authy::API).to receive(:verify).with(
+          expect(Authy::API).to receive(:verify).with({
             :id => user.authy_id,
             :token => valid_authy_token,
             :force => true
-          ).and_return(verify_success)
+          }).and_return(verify_success)
         }
 
         describe "without remembering" do
@@ -200,11 +200,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
       describe "with an invalid token" do
         before(:each) {
-          expect(Authy::API).to receive(:verify).with(
+          expect(Authy::API).to receive(:verify).with({
             :id => user.authy_id,
             :token => invalid_authy_token,
             :force => true
-          ).and_return(verify_failure)
+          }).and_return(verify_failure)
           post :POST_verify_authy, params: { :token => invalid_authy_token }
         }
 
@@ -232,11 +232,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
         end
 
         it 'locks the account when failed_attempts exceeds maximum' do
-          expect(Authy::API).to receive(:verify).exactly(Devise.maximum_attempts).times.with(
+          expect(Authy::API).to receive(:verify).exactly(Devise.maximum_attempts).times.with({
             :id => lockable_user.authy_id,
             :token => invalid_authy_token,
             :force => true
-          ).and_return(verify_failure)
+          }).and_return(verify_failure)
           (Devise.maximum_attempts).times do
             post :POST_verify_authy, params: { token: invalid_authy_token }
           end
@@ -251,11 +251,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
           request.session['user_id']               = user.id
           request.session['user_password_checked'] = true
 
-          expect(Authy::API).to receive(:verify).exactly(Devise.maximum_attempts).times.with(
+          expect(Authy::API).to receive(:verify).exactly(Devise.maximum_attempts).times.with({
             :id => user.authy_id,
             :token => invalid_authy_token,
             :force => true
-          ).and_return(verify_failure)
+          }).and_return(verify_failure)
 
           Devise.maximum_attempts.times do
             post :POST_verify_authy, params: { token: invalid_authy_token }
@@ -572,11 +572,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
           describe "successful verification" do
             before(:each) do
-              expect(Authy::API).to receive(:verify).with(
+              expect(Authy::API).to receive(:verify).with({
                 :id => user.authy_id,
                 :token => token,
                 :force => true
-              ).and_return(double("Authy::Response", :ok? => true))
+              }).and_return(double("Authy::Response", :ok? => true))
               post :POST_verify_authy_installation, :params => { :token => token, :remember_device => '0' }
             end
 
@@ -601,11 +601,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
           describe "successful verification with remember device" do
             before(:each) do
-              expect(Authy::API).to receive(:verify).with(
+              expect(Authy::API).to receive(:verify).with({
                 :id => user.authy_id,
                 :token => token,
                 :force => true
-              ).and_return(double("Authy::Response", :ok? => true))
+              }).and_return(double("Authy::Response", :ok? => true))
               post :POST_verify_authy_installation, :params => { :token => token, :remember_device => '1' }
             end
 
@@ -632,11 +632,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
 
           describe "unsuccessful verification" do
             before(:each) do
-              expect(Authy::API).to receive(:verify).with(
+              expect(Authy::API).to receive(:verify).with({
                 :id => user.authy_id,
                 :token => token,
                 :force => true
-              ).and_return(double("Authy::Response", :ok? => false))
+              }).and_return(double("Authy::Response", :ok? => false))
               post :POST_verify_authy_installation, :params => { :token => token }
             end
 
@@ -661,11 +661,11 @@ RSpec.describe Devise::DeviseAuthyController, type: :controller do
             end
 
             it "should hit API for a QR code" do
-              expect(Authy::API).to receive(:verify).with(
+              expect(Authy::API).to receive(:verify).with({
                 :id => user.authy_id,
                 :token => token,
                 :force => true
-              ).and_return(double("Authy::Response", :ok? => false))
+              }).and_return(double("Authy::Response", :ok? => false))
               expect(Authy::API).to receive(:request_qr_code).with(
                 :id => user.authy_id
               ).and_return(double("Authy::Request", :qr_code => 'https://example.com/qr.png'))

--- a/spec/generators/devise_authy/devise_authy_generator_spec.rb
+++ b/spec/generators/devise_authy/devise_authy_generator_spec.rb
@@ -37,5 +37,4 @@ RSpec.describe DeviseAuthy::Generators::DeviseAuthyGenerator, type: :generator d
       end
     }
   end
-
 end

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DeviseAuthy::Views::Helpers, type: :helper do
         assign(:resource, user)
         form = helper.verify_authy_form { "I'm in a form" }
         expect(form).to match(%r|action="/users/verify_authy"|)
-        expect(form).to match(%|<input type="hidden" name="user_id" id="user_id" value="#{user.id}" />|)
+        expect(form).to match(%|<input type="hidden" name="user_id" id="user_id" value="#{user.id}"|)
       end
     end
 


### PR DESCRIPTION
Updates to Rails now require url helper methods to take symbols as arguments, not strings.

Hidden inputs now also add autocomplete='off' to their attributes. This loosens the requirements on the test for the hidden input from the authy form helper.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
