### PR TITLE
Adds a deprecation warning that prints when you load the gem.

### DIFF
--- a/lib/devise-authy.rb
+++ b/lib/devise-authy.rb
@@ -33,3 +33,5 @@ Authy.user_agent = "DeviseAuthy/#{DeviseAuthy::VERSION} - #{Authy.user_agent}"
 
 Devise.add_module :authy_authenticatable, :model => 'devise-authy/models/authy_authenticatable', :controller => :devise_authy, :route => :authy
 Devise.add_module :authy_lockable,        :model => 'devise-authy/models/authy_lockable'
+
+warn "DEPRECATION WARNING: The authy-devise library is no longer actively maintained. The Authy API is being replaced by the Twilio Verify API. Please see the README for more details."


### PR DESCRIPTION
This adds a deprecation warning when you load the gem. I was going to release a new version (2.3.1) of the gem so that RubyGems can pick up the [new description and summary](https://github.com/twilio/authy-devise/blob/master/devise-authy.gemspec#L13-L14), so I thought, while I'm at it, why not a deprecation message for those that update their gems.

@robinske do you think this is a good idea?

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
